### PR TITLE
Fixed Array Checks and Object Enumeration

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -24,19 +24,20 @@ module.exports.generate = (form, file) ->
             /Fields [
             """
     for field, val of form
-        if typeof val is "object" and Array.isArray(val)
-            data += """<<
-                    /V(#{val})
-                    /T["""
-            for opt in val
-                data += "(" + opt + ")"
-            data += "]>>"
-        else
-            data += """<<
-                    /V(#{val})
-                    /T(#{field})
-                    >>
-                    """
+        if form.hasOwnProperty(field)
+            if typeof val is "object" and Array.isArray(val)
+                data += """<<
+                        /V(#{val})
+                        /T["""
+                for opt in val
+                    data += "(" + opt + ")"
+                data += "]>>"
+            else
+                data += """<<
+                        /V(#{val})
+                        /T(#{field})
+                        >>
+                        """
     #time_hash = md5 (new Date()).valueOf()
     data += """] 
             >>

--- a/index.js
+++ b/index.js
@@ -12,15 +12,17 @@
     data = "%FDF-1.2\n%" + header + "\n1 0 obj \n<<\n/FDF \n<<\n/Fields [";
     for (field in form) {
       val = form[field];
-      if (typeof val === "object" && Array.isArray(val)) {
-        data += "<<\n/V(" + val + ")\n/T[";
-        for (_i = 0, _len = val.length; _i < _len; _i++) {
-          opt = val[_i];
-          data += "(" + opt + ")";
+      if (form.hasOwnProperty(field)) {
+        if (typeof val === "object" && Array.isArray(val)) {
+          data += "<<\n/V(" + val + ")\n/T[";
+          for (_i = 0, _len = val.length; _i < _len; _i++) {
+            opt = val[_i];
+            data += "(" + opt + ")";
+          }
+          data += "]>>";
+        } else {
+          data += "<<\n/V(" + val + ")\n/T(" + field + ")\n>>";
         }
-        data += "]>>";
-      } else {
-        data += "<<\n/V(" + val + ")\n/T(" + field + ")\n>>";
       }
     }
     data += "] \n>>\n>>\nendobj \ntrailer\n\n<<\n/Root 1 0 R\n>>\n%%EOF";


### PR DESCRIPTION
JavaScript is a fickle beast.  As it is now, the typeof checks for an array value doesn't get fired.  When you `typeof []` it returns `"object"`, rather than `"array"` as you would expect.  

I fixed this check using the `Array.isArray()` call.  Honestly I'm not sure in what situations this would be used when writing to PDF's, so if you could supply a use-case I can check this to ensure it works as expected.

When you enumerate over objects, you also need to check to ensure prototypes do not get included in the data.  Most of the time this shouldn't be a huge issue, but when you start creating new types of objects, you can run into situations where custom-set prototypes can get included as well.  As a user you can get around this using `Object.defineProperty()`, so if you don't want this check in, I can remove it.

Check out the second answer on this SO question on that:
http://stackoverflow.com/questions/208016/how-to-list-the-properties-of-a-javascript-object
